### PR TITLE
Update the appellant in the case it is not yet in observers

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,4 +1,4 @@
-{
+module.exports = {
   "extends": [
     "udes"
   ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [2.2.1] - 2017-10-16
+### Changed
+- Update the appellant in the case it is not yet in observers.
 
-## [2.2.0] - 2017-09-26
+## [2.2.0] - 2017-09-27
 ### Added
 - Update the lang attribute of html element with the ISO 639-1 abbreviation.
 - Add a demo element.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "udes-language-mixin",
-  "version": "2.1.0",
+  "version": "2.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "udes-language-mixin",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "A simple mixin to be aware of the current language application",
   "author": "Université de Sherbrooke",
   "license": "MIT",

--- a/test/.eslintrc.js
+++ b/test/.eslintrc.js
@@ -1,0 +1,10 @@
+module.exports = {
+  "env": {
+    "mocha": true
+  },
+  "globals": {
+    "assert": false,
+    "fixture": false,
+    "WCT": false
+  }
+}

--- a/test/index.html
+++ b/test/index.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport"
+        content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
+
+  <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+  <script src="../../web-component-tester/browser.js"></script>
+</head>
+<body>
+<script>
+  // Load and run all tests (.html, .js):
+  WCT.loadSuites([
+    'udes-language-mixin.html',
+  ]);
+</script>
+</body>
+</html>

--- a/test/udes-language-mixin-test-element.html
+++ b/test/udes-language-mixin-test-element.html
@@ -1,0 +1,27 @@
+<link rel="import" href="../../polymer/polymer-element.html">
+<link rel="import" href="../udes-language-mixin.html">
+
+<script>
+  /**
+   * @polymer
+   * @customElement
+   * @memberOf UdeS
+   * @element udes-language-mixin-test-element
+   * @extends {Polymer.Element}
+   * @appliesMixin UdeS.LanguageMixin
+   */
+  class UdeSLanguageMixinTestElement extends UdeS.LanguageMixin(Polymer.Element) {
+    /**
+     * Return the HTML tag.
+     * @static
+     * @return {String} HTML tag.
+     */
+    static get is() {
+      return 'udes-language-mixin-test-element';
+    }
+  }
+
+  customElements.define(
+    UdeSLanguageMixinTestElement.is, UdeSLanguageMixinTestElement
+  );
+</script>

--- a/test/udes-language-mixin.html
+++ b/test/udes-language-mixin.html
@@ -1,0 +1,58 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
+
+  <title>udes-array-functions-mixin test</title>
+
+  <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+  <script src="../../web-component-tester/browser.js"></script>
+
+  <link rel="import" href="udes-language-mixin-test-element.html">
+</head>
+
+<body>
+  <test-fixture id="basic">
+    <template>
+      <udes-language-mixin-test-element></udes-language-mixin-test-element>
+    </template>
+  </test-fixture>
+  <script>
+    suite('<udes-language-mixin>', () => {
+      let element;
+
+      setup(() => {
+        element = fixture('basic');
+      });
+
+      suite('updateLanguage', () => {
+        test('should update the global `UdeS.Language.language` variable', () => {
+          const language = 'en-US';
+          element.updateLanguage(language);
+          assert.strictEqual(language, UdeS.Language.language);
+        });
+
+        test('should update his `language` property', () => {
+          const language = 'en-US';
+          element.updateLanguage(language);
+          assert.strictEqual(language, element.language);
+        });
+      });
+
+      suite('_updateLangAttributeOfHtml', () => {
+        test('should update the `lang` attribute of the html element', () => {
+          const language = 'en-US';
+          const expectedLang = 'en';
+          const html = document.getElementsByTagName('html')[0];
+
+          element._updateLangAttributeOfHtml(language);
+          assert.strictEqual(html.lang, expectedLang);
+        });
+      });
+    });
+  </script>
+</body>
+
+</html>

--- a/udes-language-mixin.html
+++ b/udes-language-mixin.html
@@ -155,6 +155,9 @@
      * @public
      */
     updateLanguage(language) {
+      // Update the appellant in the case it is not yet in observers
+      this.language = language;
+
       // Update the global current language
       UdeS.Language.language = language;
 


### PR DESCRIPTION
- [x] CHANGELOG.md has been updated

Il est possible qu'un élément appelle la fonction `updateLanguage` alors qu'il ne fait pas encore partie des observateurs; la méthode `ready` du mixin ne s'étant pas encore fait appelée. J'ai donc ajouté le code nécessaire pour mettre la propriété `language` à jour.

J'ai profité de ce Pull Request pour:
- Ajouter des tests unitaires pour les fonctions `updateLanguage` et `_updateLangAttributeOfHtml`;
- Renommer le fichier *.eslintrc.json* en *.eslintrc.js* tel que nous avons convenu;